### PR TITLE
[Hotfix] 글 작성후 커뮤니티 화면에서 바로 글이 불러와지지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/fork/spoonfeed/presentation/ui/communitypost/view/CommunityPostCreateActivity.kt
+++ b/app/src/main/java/com/fork/spoonfeed/presentation/ui/communitypost/view/CommunityPostCreateActivity.kt
@@ -109,10 +109,9 @@ class CommunityPostCreateActivity :
     private fun setOnClickListener() {
         binding.mbCommunityPostCreate.setOnClickListener {
             communityPostCreateViewModel.sendPost()
-            finish()
         }
         binding.mtCommunityPostCreateTitle.setNavigationOnClickListener {
-            finish()
+            communityPostCreateViewModel.sendPost()
         }
         binding.tvCommunityPostCreateCategory.setOnClickListener {
             showMenu()


### PR DESCRIPTION
## 구현한 사항
- [x] create 호출 시 finish도 같이 호출하여 POST보다 GET이 먼저 발생한 문제
  - sendSuccess를 observe 했을때만 finish를 호출하도록 수정

## 관련 이슈
- #58 
