### PR TITLE
[FEAT] 내정보 없을 때 맞춤정책 화면으로 이동 구현

### DIFF
--- a/app/src/main/java/com/fork/spoonfeed/presentation/MainActivity.kt
+++ b/app/src/main/java/com/fork/spoonfeed/presentation/MainActivity.kt
@@ -7,6 +7,7 @@ import com.fork.spoonfeed.presentation.base.BaseViewUtil
 import com.fork.spoonfeed.presentation.ui.community.view.CommunityFragment
 import com.fork.spoonfeed.presentation.ui.home.view.HomeFragment
 import com.fork.spoonfeed.presentation.ui.mypage.view.MyPageFragment
+import com.fork.spoonfeed.presentation.ui.mypage.view.MyPageMyInfoActivity
 import com.fork.spoonfeed.presentation.ui.policy.view.PolicyFragment
 import com.fork.spoonfeed.presentation.ui.policylist.view.PolicyListActivity
 import com.fork.spoonfeed.presentation.util.replace
@@ -26,7 +27,10 @@ class MainActivity : BaseViewUtil.BaseAppCompatActivity<ActivityMainBinding>(R.l
     }
 
     override fun initView() {
-        replace(homeFragment)
+        intent.getStringExtra(MyPageMyInfoActivity.MY_INFO_EMPTY_KEY)?.let {
+            replace(policyFragment)
+            moveToPolicy()
+        } ?: replace(homeFragment)
         initBottomNavigation()
 
         checkPolicyReset()

--- a/app/src/main/java/com/fork/spoonfeed/presentation/ui/communitypost/view/CommunityPostInfoUpdateActivity.kt
+++ b/app/src/main/java/com/fork/spoonfeed/presentation/ui/communitypost/view/CommunityPostInfoUpdateActivity.kt
@@ -13,8 +13,10 @@ import com.fork.spoonfeed.domain.model.HomeOwnership
 import com.fork.spoonfeed.domain.model.HouseHolderStatus
 import com.fork.spoonfeed.domain.model.MedianIncome
 import com.fork.spoonfeed.domain.model.NetWorth
+import com.fork.spoonfeed.presentation.MainActivity
 import com.fork.spoonfeed.presentation.base.BaseViewUtil
 import com.fork.spoonfeed.presentation.ui.communitypost.viewmodel.CommunityPostInfoUpdateViewModel
+import com.fork.spoonfeed.presentation.ui.mypage.view.MyPageMyInfoActivity
 import com.fork.spoonfeed.presentation.util.showFloatingDialog
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -223,6 +225,11 @@ class CommunityPostInfoUpdateActivity :
 
         inputBtn.setOnClickListener {
             dialog.dismiss()
+            startActivity(Intent(baseContext, MainActivity::class.java).apply {
+                putExtra(MyPageMyInfoActivity.MY_INFO_EMPTY_KEY, MyPageMyInfoActivity.MY_INFO_EMPTY)
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            })
         }
 
         cancelBtn.setOnClickListener {

--- a/app/src/main/java/com/fork/spoonfeed/presentation/ui/mypage/view/MyPageMyInfoActivity.kt
+++ b/app/src/main/java/com/fork/spoonfeed/presentation/ui/mypage/view/MyPageMyInfoActivity.kt
@@ -266,13 +266,22 @@ class MyPageMyInfoActivity :
 
         inputBtn.setOnClickListener {
             dialog.dismiss()
-            finish()
+            startActivity(Intent(baseContext, MainActivity::class.java).apply {
+                putExtra(MY_INFO_EMPTY_KEY, MY_INFO_EMPTY)
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            })
         }
 
         cancelBtn.setOnClickListener {
             dialog.dismiss()
             finish()
         }
+    }
+
+    companion object {
+        const val MY_INFO_EMPTY_KEY = "com.fork.spoonfeed.presentation.ui.mypage.view MY_INFO_EMPTY"
+        const val MY_INFO_EMPTY = "com.fork.spoonfeed.presentation.ui.mypage.view MY_INFO_EMPTY_KEY"
     }
 }
 


### PR DESCRIPTION
## 구현한 사항
- [x] 마이페이지 내 정보 화면에서 정보 없을때 맞춤정책 화면으로 이동 구현
- [x] 글작성 내 정보 화면에서 정보 없을때 맞춤정책 화면으로 이동 구현

## 구현 결과

https://user-images.githubusercontent.com/64943924/159406956-71477de1-350f-4434-b864-64d5361c867a.mp4



## 관련 이슈
- #89 
