### PR TITLE
[Fix] 맞춤정책 리스트 데이터 없을때 ui 반영하는 로직 수정

### DIFF
--- a/app/src/main/java/com/fork/spoonfeed/presentation/ui/policylist/view/PolicyListActivity.kt
+++ b/app/src/main/java/com/fork/spoonfeed/presentation/ui/policylist/view/PolicyListActivity.kt
@@ -114,6 +114,8 @@ class PolicyListActivity :
     private fun setPolicyListObserve() {
         policyListViewModel.policyFilteredResult.observe(this) { policyList ->
             policyListViewModel.getMyLikePolicy()
+            binding.clPolicylistEmptyData.visibility =
+                if (policyList.isNullOrEmpty()) View.VISIBLE else View.INVISIBLE
             policyListAdapter.submitList(policyList)
         }
     }

--- a/app/src/main/res/layout/activity_policy_list.xml
+++ b/app/src/main/res/layout/activity_policy_list.xml
@@ -125,9 +125,10 @@
                 </androidx.recyclerview.widget.RecyclerView>
 
                 <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/cl_policylist_empty_data"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:visibility="gone"
+                    android:visibility="invisible"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## 구현한 사항
- [x] 맞춤정책 리스트 데이터 없을때 ui 반영하는 로직 수정

## 관련 이슈
- #101 