### PR TITLE
[REFACTOR] SimpleDiffUtil() 로 변경

### DIFF
--- a/app/src/main/java/com/fork/spoonfeed/presentation/ui/communitypost/adapter/CommentAdapter.kt
+++ b/app/src/main/java/com/fork/spoonfeed/presentation/ui/communitypost/adapter/CommentAdapter.kt
@@ -15,13 +15,14 @@ import com.fork.spoonfeed.domain.model.CommentData
 import com.fork.spoonfeed.presentation.ui.communitypost.view.BottomDialogReport
 import com.fork.spoonfeed.presentation.ui.communitypost.view.CommunityPostActivity
 import com.fork.spoonfeed.presentation.ui.mypage.view.BottomDialogMyPageFragment
+import com.fork.spoonfeed.presentation.util.SimpleDiffUtil
 
 class CommentAdapter(
     private val supportFragmentManager: FragmentManager,
     private val userData: ResponseUserData.Data.User,
     private val commentUpdateListener: (ResponsePostData.Data.Comment) -> Unit,
     private val commentDeleteListener: (ResponsePostData.Data.Comment) -> Unit
-) : ListAdapter<ResponsePostData.Data.Comment, CommentAdapter.CommentViewHolder>(diffUtil) {
+) : ListAdapter<ResponsePostData.Data.Comment, CommentAdapter.CommentViewHolder>(SimpleDiffUtil()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CommentViewHolder {
         return CommentViewHolder(
@@ -98,24 +99,6 @@ class CommentAdapter(
                 supportFragmentManager,
                 bottomDialogReportUser.tag
             )
-        }
-    }
-
-    companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<ResponsePostData.Data.Comment>() {
-            override fun areContentsTheSame(
-                oldItem: ResponsePostData.Data.Comment,
-                newItem: ResponsePostData.Data.Comment
-            ): Boolean {
-                return oldItem == newItem
-            }
-
-            override fun areItemsTheSame(
-                oldItem: ResponsePostData.Data.Comment,
-                newItem: ResponsePostData.Data.Comment
-            ): Boolean {
-                return oldItem.id == newItem.id
-            }
         }
     }
 }

--- a/app/src/main/java/com/fork/spoonfeed/presentation/ui/home/adapter/MyLikePolicyHomeAdapter.kt
+++ b/app/src/main/java/com/fork/spoonfeed/presentation/ui/home/adapter/MyLikePolicyHomeAdapter.kt
@@ -8,10 +8,11 @@ import androidx.recyclerview.widget.RecyclerView
 import com.fork.spoonfeed.R
 import com.fork.spoonfeed.data.remote.model.user.ResponseUserLikePolicyData
 import com.fork.spoonfeed.databinding.ItemInterastedPolicyBinding
+import com.fork.spoonfeed.presentation.util.SimpleDiffUtil
 
 class MyLikePolicyAdapter(
     private val clickListener: (ResponseUserLikePolicyData.Data.Policy) -> Unit
-) : ListAdapter<ResponseUserLikePolicyData.Data.Policy, MyLikePolicyAdapter.MyLikePolicyHomeViewHolder>(diffUtil) {
+) : ListAdapter<ResponseUserLikePolicyData.Data.Policy, MyLikePolicyAdapter.MyLikePolicyHomeViewHolder>(SimpleDiffUtil()) {
 
     inner class MyLikePolicyHomeViewHolder(private val binding: ItemInterastedPolicyBinding) : RecyclerView.ViewHolder(binding.root) {
         fun onBind(data: ResponseUserLikePolicyData.Data.Policy) {
@@ -52,19 +53,12 @@ class MyLikePolicyAdapter(
             currentList.size
         }
 
-    override fun onBindViewHolder(holder: MyLikePolicyAdapter.MyLikePolicyHomeViewHolder, position: Int) { holder.onBind(getItem(position))
+    override fun onBindViewHolder(holder: MyLikePolicyAdapter.MyLikePolicyHomeViewHolder, position: Int) {
+        holder.onBind(getItem(position))
 
     }
 
     companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<ResponseUserLikePolicyData.Data.Policy>() {
-            override fun areContentsTheSame(oldItem: ResponseUserLikePolicyData.Data.Policy, newItem: ResponseUserLikePolicyData.Data.Policy) =
-                oldItem == newItem
-
-            override fun areItemsTheSame(oldItem: ResponseUserLikePolicyData.Data.Policy, newItem: ResponseUserLikePolicyData.Data.Policy) =
-                oldItem.policyId == newItem.policyId
-        }
-
         const val DEFAULT_COUNT = 3
     }
 }

--- a/app/src/main/java/com/fork/spoonfeed/presentation/ui/mypage/adapter/MyCommentAdapter.kt
+++ b/app/src/main/java/com/fork/spoonfeed/presentation/ui/mypage/adapter/MyCommentAdapter.kt
@@ -10,11 +10,12 @@ import androidx.recyclerview.widget.RecyclerView
 import com.fork.spoonfeed.data.remote.model.user.ResponseUserCommentData
 import com.fork.spoonfeed.databinding.ItemCommentBinding
 import com.fork.spoonfeed.presentation.ui.mypage.view.BottomDialogMyPageFragment
+import com.fork.spoonfeed.presentation.util.SimpleDiffUtil
 
 class MyCommentAdapter(
     private val supportFragmentManager: FragmentManager,
     private val clickListener: (ResponseUserCommentData.Data.Comment) -> Unit
-) : ListAdapter<ResponseUserCommentData.Data.Comment, MyCommentAdapter.MyCommentViewHolder>(diffUtil) {
+) : ListAdapter<ResponseUserCommentData.Data.Comment, MyCommentAdapter.MyCommentViewHolder>(SimpleDiffUtil()) {
 
     inner class MyCommentViewHolder(private val binding: ItemCommentBinding) : RecyclerView.ViewHolder(binding.root) {
         fun onBind(data: ResponseUserCommentData.Data.Comment) {
@@ -55,15 +56,5 @@ class MyCommentAdapter(
             supportFragmentManager,
             bottomSheetFragment.tag
         )
-    }
-
-    companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<ResponseUserCommentData.Data.Comment>() {
-            override fun areContentsTheSame(oldItem: ResponseUserCommentData.Data.Comment, newItem: ResponseUserCommentData.Data.Comment) =
-                oldItem == newItem
-
-            override fun areItemsTheSame(oldItem: ResponseUserCommentData.Data.Comment, newItem: ResponseUserCommentData.Data.Comment) =
-                oldItem.commentId == newItem.commentId
-        }
     }
 }

--- a/app/src/main/java/com/fork/spoonfeed/presentation/ui/mypage/adapter/MyLikePolicyAdapter.kt
+++ b/app/src/main/java/com/fork/spoonfeed/presentation/ui/mypage/adapter/MyLikePolicyAdapter.kt
@@ -11,11 +11,12 @@ import com.fork.spoonfeed.R
 import com.fork.spoonfeed.data.remote.model.user.ResponseUserLikePolicyData
 import com.fork.spoonfeed.databinding.ItemPolicyListBinding
 import com.fork.spoonfeed.presentation.ui.mypage.viewmodel.MyPageViewModel
+import com.fork.spoonfeed.presentation.util.SimpleDiffUtil
 
 class MyLikePolicyAdapter(
     private val myPageViewModel: MyPageViewModel,
     private val clickListener: (ResponseUserLikePolicyData.Data.Policy) -> Unit
-) : ListAdapter<ResponseUserLikePolicyData.Data.Policy, MyLikePolicyAdapter.MyLikePolicyViewHolder>(diffUtil) {
+) : ListAdapter<ResponseUserLikePolicyData.Data.Policy, MyLikePolicyAdapter.MyLikePolicyViewHolder>(SimpleDiffUtil()) {
 
     inner class MyLikePolicyViewHolder(private val binding: ItemPolicyListBinding) : RecyclerView.ViewHolder(binding.root) {
         fun onBind(data: ResponseUserLikePolicyData.Data.Policy) {
@@ -61,15 +62,5 @@ class MyLikePolicyAdapter(
 
     override fun onBindViewHolder(holder: MyLikePolicyAdapter.MyLikePolicyViewHolder, position: Int) {
         holder.onBind(currentList[position])
-    }
-
-    companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<ResponseUserLikePolicyData.Data.Policy>() {
-            override fun areContentsTheSame(oldItem: ResponseUserLikePolicyData.Data.Policy, newItem: ResponseUserLikePolicyData.Data.Policy) =
-                oldItem == newItem
-
-            override fun areItemsTheSame(oldItem: ResponseUserLikePolicyData.Data.Policy, newItem: ResponseUserLikePolicyData.Data.Policy) =
-                oldItem.policyId == newItem.policyId
-        }
     }
 }

--- a/app/src/main/java/com/fork/spoonfeed/presentation/ui/mypage/adapter/MyPostAdapter.kt
+++ b/app/src/main/java/com/fork/spoonfeed/presentation/ui/mypage/adapter/MyPostAdapter.kt
@@ -13,12 +13,13 @@ import com.fork.spoonfeed.data.remote.model.user.ResponseUserPostData
 import com.fork.spoonfeed.databinding.ItemPostBinding
 import com.fork.spoonfeed.presentation.ui.mypage.view.BottomDialogMyPageFragment
 import com.fork.spoonfeed.presentation.ui.mypage.viewmodel.MyPageViewModel
+import com.fork.spoonfeed.presentation.util.SimpleDiffUtil
 
 class MyPostAdapter(
     private val supportFragmentManager: FragmentManager,
     private val myPageViewModel: MyPageViewModel,
     private val clickListener: (ResponseUserPostData.Data.Post) -> Unit
-) : ListAdapter<ResponseUserPostData.Data.Post, MyPostAdapter.MyPostViewHolder>(diffUtil) {
+) : ListAdapter<ResponseUserPostData.Data.Post, MyPostAdapter.MyPostViewHolder>(SimpleDiffUtil()) {
 
     inner class MyPostViewHolder(private val binding: ItemPostBinding) : RecyclerView.ViewHolder(binding.root) {
         fun onBind(data: ResponseUserPostData.Data.Post) {
@@ -68,15 +69,5 @@ class MyPostAdapter(
             supportFragmentManager,
             bottomSheetFragment.tag
         )
-    }
-
-    companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<ResponseUserPostData.Data.Post>() {
-            override fun areContentsTheSame(oldItem: ResponseUserPostData.Data.Post, newItem: ResponseUserPostData.Data.Post) =
-                oldItem == newItem
-
-            override fun areItemsTheSame(oldItem: ResponseUserPostData.Data.Post, newItem: ResponseUserPostData.Data.Post) =
-                oldItem.postId == newItem.postId
-        }
     }
 }

--- a/app/src/main/java/com/fork/spoonfeed/presentation/ui/mypage/adapter/NoticeAdapter.kt
+++ b/app/src/main/java/com/fork/spoonfeed/presentation/ui/mypage/adapter/NoticeAdapter.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.fork.spoonfeed.databinding.ItemCommentBinding
 import com.fork.spoonfeed.databinding.ItemNoticeBinding
+import com.fork.spoonfeed.presentation.util.SimpleDiffUtil
 
 
 data class NoticeResponseData(
@@ -19,7 +20,7 @@ data class NoticeResponseData(
 class NoticeAdapter(
     private val postList: List<NoticeResponseData>,
     private val clickListener: (NoticeResponseData) -> Unit
-) : ListAdapter<NoticeResponseData, NoticeAdapter.NoticeViewHolder>(diffUtil) {
+) : ListAdapter<NoticeResponseData, NoticeAdapter.NoticeViewHolder>(SimpleDiffUtil()) {
 
     inner class NoticeViewHolder(private val binding: ItemNoticeBinding) : RecyclerView.ViewHolder(binding.root) {
         fun onBind(data: NoticeResponseData) {
@@ -42,15 +43,5 @@ class NoticeAdapter(
 
     override fun onBindViewHolder(holder: NoticeViewHolder, position: Int) {
         holder.onBind(postList[position])
-    }
-
-    companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<NoticeResponseData>() {
-            override fun areContentsTheSame(oldItem: NoticeResponseData, newItem: NoticeResponseData) =
-                oldItem == newItem
-
-            override fun areItemsTheSame(oldItem: NoticeResponseData, newItem: NoticeResponseData) =
-                oldItem.id == newItem.id
-        }
     }
 }

--- a/app/src/main/java/com/fork/spoonfeed/presentation/ui/policylist/adapter/PolicyListAdapter.kt
+++ b/app/src/main/java/com/fork/spoonfeed/presentation/ui/policylist/adapter/PolicyListAdapter.kt
@@ -10,12 +10,13 @@ import com.fork.spoonfeed.R
 import com.fork.spoonfeed.data.remote.model.policy.ResponsePolicyAllData
 import com.fork.spoonfeed.databinding.ItemPolicyListBinding
 import com.fork.spoonfeed.presentation.ui.policylist.viewmodel.PolicyListViewModel
+import com.fork.spoonfeed.presentation.util.SimpleDiffUtil
 
 class PolicyListAdapter(
     private val context: LifecycleOwner,
     private val policyListViewModel: PolicyListViewModel,
     private val clickListener: (ResponsePolicyAllData.Data.Policy) -> Unit
-) : ListAdapter<ResponsePolicyAllData.Data.Policy, PolicyListAdapter.PolicyListViewHolder>(diffUtil) {
+) : ListAdapter<ResponsePolicyAllData.Data.Policy, PolicyListAdapter.PolicyListViewHolder>(SimpleDiffUtil()) {
 
 
     inner class PolicyListViewHolder(private val binding: ItemPolicyListBinding) : RecyclerView.ViewHolder(binding.root) {
@@ -76,15 +77,5 @@ class PolicyListAdapter(
 
     override fun onBindViewHolder(holder: PolicyListViewHolder, position: Int) {
         holder.onBind(currentList[position])
-    }
-
-    companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<ResponsePolicyAllData.Data.Policy>() {
-            override fun areContentsTheSame(oldItem: ResponsePolicyAllData.Data.Policy, newItem: ResponsePolicyAllData.Data.Policy) =
-                oldItem == newItem
-
-            override fun areItemsTheSame(oldItem: ResponsePolicyAllData.Data.Policy, newItem: ResponsePolicyAllData.Data.Policy) =
-                oldItem.id == newItem.id
-        }
     }
 }

--- a/app/src/main/java/com/fork/spoonfeed/presentation/util/SimpleDiffUtil.kt
+++ b/app/src/main/java/com/fork/spoonfeed/presentation/util/SimpleDiffUtil.kt
@@ -1,0 +1,15 @@
+package com.fork.spoonfeed.presentation.util
+
+import android.annotation.SuppressLint
+import androidx.recyclerview.widget.DiffUtil
+
+class SimpleDiffUtil<T : Any> : DiffUtil.ItemCallback<T>() {
+    override fun areItemsTheSame(oldItem: T, newItem: T): Boolean {
+        return oldItem == newItem
+    }
+
+    @SuppressLint("DiffUtilEquals")
+    override fun areContentsTheSame(oldItem: T, newItem: T): Boolean {
+        return oldItem == newItem
+    }
+}


### PR DESCRIPTION
## 구현한 사항
- [ ] DiffUtil-> SimpleDiffUtil 사용으로 보일러 플레이트 코드 감소

```kotlin
class SimpleDiffUtil<T : Any> : DiffUtil.ItemCallback<T>() {
    override fun areItemsTheSame(oldItem: T, newItem: T): Boolean {
        return oldItem == newItem
    }

    @SuppressLint("DiffUtilEquals")
    override fun areContentsTheSame(oldItem: T, newItem: T): Boolean {
        return oldItem == newItem
    }
}
```

* 아래와 같이 사용할 수 있습니다
```kotlin
class PolicyListAdapter : ListAdapter<ResponsePolicyAllData.Data.Policy, PolicyListAdapter.PolicyListViewHolder(SimpleDiffUtil()){
...
}
```